### PR TITLE
Update build requirement to Xcode 9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ supported host development operating systems.
 
 #### macOS
 
-To build for macOS, you need [Xcode 9.3 beta](https://developer.apple.com/xcode/downloads/).
+To build for macOS, you need [Xcode 9.3](https://developer.apple.com/xcode/downloads/).
 The required version of Xcode changes frequently, and is often a beta release.
 Check this document or the host information on <https://ci.swift.org> for the
 current required version.


### PR DESCRIPTION
**What's in this pull request?**
The system requirements now state that Xcode 9.3 is needed for building on macOS.

Previously the Readme referred to _Xcode 9.3 beta_.